### PR TITLE
Reworked save confirmation dialog to allow cancel option

### DIFF
--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -116,7 +116,7 @@ class TextDisplay(gtk.TextView):
         menu.show_all()
         return False
 
-def MessageDialogHelper(type, buttons, title=None, markup=None):
+def MessageDialogHelper(type, buttons, title=None, markup=None, extra_buttons=None):
     """
     Create a modal message dialog and run it.
 
@@ -126,8 +126,9 @@ def MessageDialogHelper(type, buttons, title=None, markup=None):
         gtk.BUTTONS_NONE, gtk.BUTTONS_OK, gtk.BUTTONS_CLOSE, gtk.BUTTONS_CANCEL, gtk.BUTTONS_YES_NO, gtk.BUTTONS_OK_CANCEL
 
     Args:
-        tittle: the title of the window (string)
+        title: the title of the window (string)
         markup: the message text with pango markup
+        extra_buttons: a tuple containing pairs of values, each value is the button's text and the button's return value
 
     Returns:
         the gtk response from run()
@@ -135,6 +136,7 @@ def MessageDialogHelper(type, buttons, title=None, markup=None):
     message_dialog = gtk.MessageDialog(None, gtk.DIALOG_MODAL, type, buttons)
     if title: message_dialog.set_title(title)
     if markup: message_dialog.set_markup(markup)
+    if extra_buttons: message_dialog.add_buttons(*extra_buttons)
     response = message_dialog.run()
     message_dialog.destroy()
     return response

--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -128,7 +128,7 @@ def MessageDialogHelper(type, buttons, title=None, markup=None, extra_buttons=No
     Args:
         title: the title of the window (string)
         markup: the message text with pango markup
-        extra_buttons: a tuple containing pairs of values, each value is the button's text and the button's return value
+        extra_buttons: a tuple containing pairs of values; each value is the button's text and the button's return value
 
     Returns:
         the gtk response from run()

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -236,10 +236,14 @@ class MainWindow(gtk.Window):
         if self.page_to_be_closed.get_proc() or not self.page_to_be_closed.get_saved():
             self._set_page(self.page_to_be_closed)
         #unsaved? ask the user
-        if not self.page_to_be_closed.get_saved() and self._save_changes():
-            Actions.FLOW_GRAPH_SAVE() #try to save
-            if not self.page_to_be_closed.get_saved(): #still unsaved?
-                self.page_to_be_closed = None #set the page to be closed back to None
+        if not self.page_to_be_closed.get_saved():
+            response = self._save_changes() # return value is either OK, CLOSE, or CANCEL
+            if response == gtk.RESPONSE_OK:
+                Actions.FLOW_GRAPH_SAVE() #try to save
+                if not self.page_to_be_closed.get_saved(): #still unsaved?
+                    self.page_to_be_closed = None #set the page to be closed back to None
+                    return
+            elif response == gtk.RESPONSE_CANCEL:
                 return
         #stop the flow graph if executing
         if self.page_to_be_closed.get_proc(): Actions.FLOW_GRAPH_KILL()
@@ -339,10 +343,15 @@ class MainWindow(gtk.Window):
         Returns:
             true if yes
         """
+        buttons = (
+            'Close without saving', gtk.RESPONSE_CLOSE,
+            gtk.STOCK_CANCEL, gtk.RESPONSE_CANCEL,
+            gtk.STOCK_SAVE, gtk.RESPONSE_OK
+        )
         return MessageDialogHelper(
-            gtk.MESSAGE_QUESTION, gtk.BUTTONS_YES_NO, 'Unsaved Changes!',
-            'Would you like to save changes before closing?'
-        ) == gtk.RESPONSE_YES
+            gtk.MESSAGE_QUESTION, gtk.BUTTONS_NONE, 'Unsaved Changes!',
+            'Would you like to save changes before closing?', buttons
+        )
 
     def _get_files(self):
         """


### PR DESCRIPTION
The old save dialog only offered the options "Yes" and "No", which meant that accidentally clicking the X on a tab or on the toolbar left the user without the option to cancel closing the file. I added that option and renamed the buttons to match conventions used by other GTK apps.