### PR TITLE
Default button in save dialog is now 'save'

### DIFF
--- a/grc/gui/Dialogs.py
+++ b/grc/gui/Dialogs.py
@@ -116,7 +116,7 @@ class TextDisplay(gtk.TextView):
         menu.show_all()
         return False
 
-def MessageDialogHelper(type, buttons, title=None, markup=None, extra_buttons=None):
+def MessageDialogHelper(type, buttons, title=None, markup=None, default_response=None, extra_buttons=None):
     """
     Create a modal message dialog and run it.
 
@@ -128,6 +128,7 @@ def MessageDialogHelper(type, buttons, title=None, markup=None, extra_buttons=No
     Args:
         title: the title of the window (string)
         markup: the message text with pango markup
+        default_response: if set, determines which button is highlighted by default
         extra_buttons: a tuple containing pairs of values; each value is the button's text and the button's return value
 
     Returns:
@@ -137,6 +138,7 @@ def MessageDialogHelper(type, buttons, title=None, markup=None, extra_buttons=No
     if title: message_dialog.set_title(title)
     if markup: message_dialog.set_markup(markup)
     if extra_buttons: message_dialog.add_buttons(*extra_buttons)
+    if default_response: message_dialog.set_default_response(default_response)
     response = message_dialog.run()
     message_dialog.destroy()
     return response

--- a/grc/gui/MainWindow.py
+++ b/grc/gui/MainWindow.py
@@ -351,7 +351,7 @@ class MainWindow(gtk.Window):
         )
         return MessageDialogHelper(
             gtk.MESSAGE_QUESTION, gtk.BUTTONS_NONE, 'Unsaved Changes!',
-            'Would you like to save changes before closing?', buttons
+            'Would you like to save changes before closing?', gtk.RESPONSE_OK, buttons
         )
 
     def _get_files(self):


### PR DESCRIPTION
GTK defaults to the leftmost button, which is "close without saving". That's bad. Now it's explicitly set to "Save"