### PR TITLE
grc: Add check for GTK initialization

### DIFF
--- a/grc/scripts/gnuradio-companion
+++ b/grc/scripts/gnuradio-companion
@@ -55,6 +55,14 @@ def show_gtk_error_dialog(title, message):
     d.run()
 
 
+def check_gtk_init():
+    try:
+        gtk.init_check()
+    except RuntimeError:
+        print 'GTK initialization failed - bailing'
+        sys.exit()
+
+
 def check_gnuradio_import():
     try:
         from gnuradio import gr
@@ -108,6 +116,7 @@ def main():
 
 
 if __name__ == '__main__':
+    check_gtk_init()
     check_gnuradio_import()
     ensure_blocks_path()
     main()


### PR DESCRIPTION
Ensure GTK can be initialized before application start-up (e.g. if X11 forwarding is not enabled on an SSH connection) to avoid a fatal error (e.g. segfault)

This is a workaround for this GTK bug: https://bugzilla.gnome.org/show_bug.cgi?id=563823