### PR TITLE
Added UUIDs to all blocks.

### DIFF
--- a/grc/base/Block.py
+++ b/grc/base/Block.py
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 """
 
 from . import odict
+from . uuid_helper import valid_uuid_or_new
 from . Constants import ADVANCED_PARAM_TAB, DEFAULT_PARAM_TAB
 from . Constants import BLOCK_FLAG_THROTTLE, BLOCK_FLAG_DISABLE_BYPASS
 from . Constants import BLOCK_ENABLED, BLOCK_BYPASSED, BLOCK_DISABLED
@@ -90,7 +91,7 @@ class Block(Element):
         self._bussify_sink = n.find('bus_sink')
         self._bussify_source = n.find('bus_source')
         self._var_value = n.find('var_value') or '$value'
-
+        
         # get list of param tabs
         n_tabs = n.find('param_tab_order') or None
         self._param_tab_labels = n_tabs.findall('tab') if n_tabs is not None else [DEFAULT_PARAM_TAB]
@@ -98,6 +99,16 @@ class Block(Element):
         #create the param objects
         self._params = list()
         #add the id param
+        self.get_params().append(self.get_parent().get_parent().Param(
+            block=self,
+            n=odict({
+                'name': 'UUID',
+                'key': 'uuid',
+                'type': 'uuid',
+                'readonly': True,
+                'tab': ADVANCED_PARAM_TAB
+            })
+        ))
         self.get_params().append(self.get_parent().get_parent().Param(
             block=self,
             n=odict({
@@ -306,6 +317,7 @@ class Block(Element):
 
     def __str__(self): return 'Block - %s - %s(%s)'%(self.get_id(), self.get_name(), self.get_key())
 
+    def get_uuid(self): return self.get_param('uuid').get_value()
     def get_id(self): return self.get_param('id').get_value()
     def is_block(self): return True
     def get_name(self): return self._name
@@ -503,6 +515,7 @@ class Block(Element):
             n['bus_sink'] = str(1);
         if 'bus' in map(lambda a: a.get_type(), self.get_sources()):
             n['bus_source'] = str(1);
+            
         return n
 
     def import_data(self, n):

--- a/grc/base/CMakeLists.txt
+++ b/grc/base/CMakeLists.txt
@@ -20,6 +20,7 @@
 ########################################################################
 GR_PYTHON_INSTALL(FILES
     odict.py
+    uuid_helper.py
     ParseXML.py
     Block.py
     Connection.py

--- a/grc/base/FlowGraph.py
+++ b/grc/base/FlowGraph.py
@@ -21,6 +21,7 @@ import time
 from . import odict
 from Element import Element
 from .. gui import Messages
+from . import uuid_helper
 from . Constants import FLOW_GRAPH_FILE_FORMAT_VERSION
 
 
@@ -59,6 +60,13 @@ class FlowGraph(Element):
             index += 1
             #make sure that the id is not used by another block
             if not filter(lambda b: b.get_id() == id, self.get_blocks()): return id
+
+    def _get_new_uuid_if_necessary(self, old_uuid):
+        if filter(lambda b: b.get_uuid() == old_uuid, self.get_blocks()):
+            # Already have this uuid
+            return uuid_helper.new_uuid()
+        else:
+            return old_uuid
 
     def __str__(self):
         return 'FlowGraph - %s(%s)' % (self.get_option('title'), self.get_option('id'))
@@ -126,7 +134,7 @@ class FlowGraph(Element):
         return sorted(self.get_blocks_unordered(), key=lambda b: (
             b.get_key() != 'options',  # options to the front
             not b.get_key().startswith('variable'),  # then vars
-            str(b)
+            str(b.get_uuid())
         ))
     def get_connections(self): return filter(lambda e: e.is_connection(), self.get_elements())
     def get_children(self): return self.get_elements()

--- a/grc/base/Param.py
+++ b/grc/base/Param.py
@@ -82,6 +82,7 @@ class Param(Element):
         value = n.find('value') or ''
         self._type = n.find('type') or 'raw'
         self._hide = n.find('hide') or ''
+        self._readonly = bool(n.find('readonly'))
         self._tab_label = n.find('tab') or block.get_param_tab_labels()[0]
         if not self._tab_label in block.get_param_tab_labels():
             block.get_param_tab_labels().append(self._tab_label)
@@ -155,6 +156,7 @@ class Param(Element):
 
     def get_type(self): return self.get_parent().resolve_dependencies(self._type)
     def get_tab_label(self): return self._tab_label
+    def is_readonly(self): return self._readonly
     def is_enum(self): return self._type == 'enum'
 
     def __repr__(self):

--- a/grc/base/uuid_helper.py
+++ b/grc/base/uuid_helper.py
@@ -1,0 +1,49 @@
+"""
+Copyright 2008-2015 Free Software Foundation, Inc.
+This file is part of GNU Radio
+
+GNU Radio Companion is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+GNU Radio Companion is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
+"""
+
+import uuid
+
+def valid_uuid_or_none(existing_uuid):
+    # Is it already a UUID object?
+    if type(existing_uuid) is uuid.UUID:
+        return str(existing_uuid)
+        
+    # Is it a string (or string-compatible) that can be converted to a UUID?
+    try:
+        converted_uuid = uuid.UUID(existing_uuid)
+        return str(converted_uuid)
+    except (AttributeError, TypeError, ValueError):
+        # Not valid!
+        # AttributeError happens if input is not string-like
+        # TypeError happens if the input is None
+        # ValueError happens if the string is not a valid UUID
+        return None
+
+def valid_uuid_or_new(existing_uuid):
+    this_uuid = valid_uuid_or_none(existing_uuid)
+        
+    if this_uuid is None:
+        # Create a new UUID from scratch, totally randomly
+        return new_uuid()
+    else:
+        # Return the existing UUID
+        return this_uuid
+
+def new_uuid():
+    return str(uuid.uuid4())

--- a/grc/gui/FlowGraph.py
+++ b/grc/gui/FlowGraph.py
@@ -18,10 +18,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 """
 
 from Constants import SCROLL_PROXIMITY_SENSITIVITY, SCROLL_DISTANCE
+
 import Actions
 import Colors
 import Utils
+
 from Element import Element
+from .. base import uuid_helper
+
 import pygtk
 pygtk.require('2.0')
 import gtk
@@ -78,6 +82,7 @@ class FlowGraph(Element):
             key: the block key
             coor: an optional coordinate or None for random
         """
+        uuid = uuid_helper.new_uuid()
         id = self._get_unique_id(key)
         #calculate the position coordinate
         h_adj = self.get_scroll_pane().get_hadjustment()
@@ -90,6 +95,7 @@ class FlowGraph(Element):
         block = self.get_new_block(key)
         block.set_coordinate(coor)
         block.set_rotation(0)
+        block.get_param('uuid').set_value(uuid)
         block.get_param('id').set_value(id)
         Actions.ELEMENT_CREATE()
         return id
@@ -157,6 +163,8 @@ class FlowGraph(Element):
                     #if the block id is not unique, get a new block id
                     if param_value in [bluck.get_id() for bluck in self.get_blocks()]:
                         param_value = self._get_unique_id(param_value)
+                elif param_key == 'uuid':
+                    param_value = self._get_new_uuid_if_necessary(param_value)
                 #set value to key
                 block.get_param(param_key).set_value(param_value)
             #move block to offset coordinate

--- a/grc/gui/Param.py
+++ b/grc/gui/Param.py
@@ -180,6 +180,22 @@ class EnumParam(InputParam):
             pass  # no tooltips for old GTK
 
 
+class ReadOnlyParam(InputParam):
+    """Provide a label to show the value of a read-only parameter."""
+
+    def __init__(self, *args, **kwargs):
+        InputParam.__init__(self, *args, **kwargs)
+        self._input = gtk.Label()
+        self._input.set_text(self.param.get_value())
+        self.pack_start(self._input, False)
+    def get_text(self): return self.param.get_text()
+    def set_tooltip_text(self, text):
+        try:
+            self._input.set_tooltip_text(text)
+        except AttributeError:
+            pass  # no tooltips for old GTK
+
+
 class EnumEntryParam(InputParam):
     """Provide an entry box and drop down menu for Raw Enum types."""
 
@@ -306,6 +322,9 @@ class Param(Element):
         """
         if self.get_type() in ('file_open', 'file_save'):
             input_widget = FileParam(self, *args, **kwargs)
+            
+        elif self.is_readonly():
+            input_widget = ReadOnlyParam(self, *args, **kwargs)
 
         elif self.is_enum():
             input_widget = EnumParam(self, *args, **kwargs)

--- a/grc/python/Param.py
+++ b/grc/python/Param.py
@@ -58,7 +58,7 @@ class Param(_Param, _GUIParam):
         'complex_vector', 'real_vector', 'float_vector', 'int_vector',
         'hex', 'string', 'bool',
         'file_open', 'file_save', 'multiline',
-        'id', 'stream_id',
+        'uuid', 'id', 'stream_id',
         'grid_pos', 'notebook', 'gui_hint',
         'import',
     )
@@ -139,12 +139,13 @@ class Param(_Param, _GUIParam):
                 #vector types
                 'complex_vector': Constants.COMPLEX_VECTOR_COLOR_SPEC,
                 'real_vector': Constants.FLOAT_VECTOR_COLOR_SPEC,
-                                'float_vector': Constants.FLOAT_VECTOR_COLOR_SPEC,
+                'float_vector': Constants.FLOAT_VECTOR_COLOR_SPEC,
                 'int_vector': Constants.INT_VECTOR_COLOR_SPEC,
                 #special
                 'bool': Constants.INT_COLOR_SPEC,
                 'hex': Constants.INT_COLOR_SPEC,
                 'string': Constants.BYTE_VECTOR_COLOR_SPEC,
+                'uuid': Constants.ID_COLOR_SPEC,
                 'id': Constants.ID_COLOR_SPEC,
                 'stream_id': Constants.ID_COLOR_SPEC,
                 'grid_pos': Constants.INT_VECTOR_COLOR_SPEC,
@@ -166,6 +167,8 @@ class Param(_Param, _GUIParam):
         """
         hide = _Param.get_hide(self)
         if hide: return hide
+        #completely hide UUIDs
+        if self.get_key() == 'uuid': return 'part'
         #hide ID in non variable blocks
         if self.get_key() == 'id' and not _show_id_matcher.match(self.get_parent().get_key()): return 'part'
         #hide port controllers for type and nports
@@ -282,6 +285,10 @@ class Param(_Param, _GUIParam):
                 self._stringify_flag = True
                 e = v
             return str(e)
+        #########################
+        # UUID Type
+        #########################
+        elif t == 'uuid': return v      # not evaluated because it's read-only
         #########################
         # Unique ID Type
         #########################


### PR DESCRIPTION
Imported `.grc` files will have UUIDs assigned to any blocks that do not yet have them. The UUID is visible (read-only) on the Advanced tab of the properties page. UUID is used to sort blocks (after prioritizing Options and Variable blocks), which should minimize changes to the `.grc` file when saving. The UUID of a block is shown in a read-only label on the Advanced tab of the properties dialog.

I have tested:
- Creation of new GRC graphs: the Options and `samp_rate` blocks are given UUIDs from the start)
- Loading existing (non-UUID) graphs: any blocks with a missing or invalid UUID will be given a new random UUID
- Copy/cut/paste: when copying a block, the copy gets a new UUID when pasted. When a block is cut, it will maintain its UUID as long as it's the first paste. Subsequent pastes should have a new UUID.
- The UUID is ignored and discarded when loading and saving in old versions of GRC (somewhat backward compatible).