### PR TITLE
Auto-Generate missing hier blocks

### DIFF
--- a/grc/base/FlowGraph.py
+++ b/grc/base/FlowGraph.py
@@ -368,7 +368,7 @@ class FlowGraph(Element):
                 block = self.get_new_block('dummy_block')
                 # Ugly ugly ugly
                 _initialize_dummy_block(block, block_n)
-                Messages.send_error_msg_load('Block key "%s" not found in %s' % (key, self.get_parent()))
+                Messages.send_error_msg_load('Block key "%s" not found' % key)
 
             block.import_data(block_n)
         #build the connections

--- a/grc/base/Platform.py
+++ b/grc/base/Platform.py
@@ -122,7 +122,7 @@ class Platform(_Element):
         # get block instance and add it to the list of blocks
         block = self.Block(self._flow_graph, n)
         key = block.get_key()
-        if key in self.get_block_keys():  # test against repeated keys
+        if key in self._blocks:
             print >> sys.stderr, 'Warning: Block with key "%s" already exists.\n\tIgnoring: %s' % (key, xml_file)
         else:  # store the block
             self._blocks[key] = block

--- a/grc/blocks/options.xml
+++ b/grc/blocks/options.xml
@@ -207,6 +207,14 @@ part#slurp
 #end if</hide>
 		<tab>Advanced</tab>
 	</param>
+	<param>
+		<name>Hier Block Source Path</name>
+		<key>hier_block_src_path</key>
+		<value>.:</value>
+		<type>string</type>
+		<hide>part</hide>
+		<tab>Advanced</tab>
+	</param>
 	<check>not $window_size or len($window_size) == 2</check>
 	<check>not $window_size or 300 &lt;= $(window_size)[0] &lt;= 4096</check>
 	<check>not $window_size or 300 &lt;= $(window_size)[1] &lt;= 4096</check>

--- a/grc/gui/Messages.py
+++ b/grc/gui/Messages.py
@@ -21,8 +21,9 @@ import traceback
 import sys
 import os
 
-## A list of functions that can receive a message.
+#  A list of functions that can receive a message.
 MESSENGERS_LIST = list()
+_indent = ''
 
 
 def register_messenger(messenger):
@@ -35,6 +36,11 @@ def register_messenger(messenger):
     MESSENGERS_LIST.append(messenger)
 
 
+def set_indent(level=0):
+    global _indent
+    _indent = '    ' * level
+
+
 def send(message):
     """
     Give the message to each of the messengers.
@@ -42,17 +48,22 @@ def send(message):
     Args:
         message: a message string
     """
-    for messenger in MESSENGERS_LIST: messenger(message)
+    for messenger in MESSENGERS_LIST:
+        messenger(_indent + message)
 
-#register stdout by default
+# register stdout by default
 register_messenger(sys.stdout.write)
+
 
 ###########################################################################
 # Special functions for specific program functionalities
 ###########################################################################
 def send_init(platform):
     p = platform
-    get_paths = lambda x: (os.path.abspath(os.path.expanduser(x)), x)
+
+    def get_paths(x):
+        return os.path.abspath(os.path.expanduser(x)), x
+
     send('\n'.join([
         "<<< Welcome to %s %s >>>" % (p.get_name(), p.get_version()),
         "",
@@ -60,71 +71,83 @@ def send_init(platform):
         "Block paths:"
     ] + [
         "\t%s" % path + (" (%s)" % opath if opath != path else "")
-            for path, opath in map(get_paths, p.get_block_paths())
+        for path, opath in map(get_paths, p.get_block_paths())
     ]) + "\n")
 
-def send_page_switch(file_path):
-    send('\nShowing: "%s"\n'%file_path)
 
-################# functions for loading blocks ########################################
+def send_page_switch(file_path):
+    send('\nShowing: "%s"\n' % file_path)
+
+
 def send_xml_errors_if_any(xml_failures):
     if xml_failures:
-        send('\nXML parser: Found {0} erroneous XML file{1} while loading the block tree '
-             '(see "Help/Parser errors" for details)\n'.format(len(xml_failures), 's' if len(xml_failures) > 1 else ''))
+        send('\nXML parser: Found {0} erroneous XML file{1} while loading the '
+             'block tree (see "Help/Parser errors" for details)\n'.format(
+                    len(xml_failures), 's' if len(xml_failures) > 1 else ''))
 
-################# functions for loading flow graphs ########################################
+
 def send_start_load(file_path):
-    send('\nLoading: "%s"'%file_path + '\n')
+    send('\nLoading: "%s"\n' % file_path)
+
 
 def send_error_msg_load(error):
     send('>>> Error: %s\n' % error)
+
 
 def send_error_load(error):
     send_error_msg_load(error)
     traceback.print_exc()
 
+
 def send_end_load():
     send('>>> Done\n')
 
+
 def send_fail_load(error):
-    send('Error: %s\n'%error)
-    send('>>> Failure\n')
+    send('Error: %s\n>>> Failure\n' % error)
     traceback.print_exc()
 
-################# functions for generating flow graphs  ########################################
+
 def send_start_gen(file_path):
-    send('\nGenerating: "%s"'%file_path + '\n')
+    send('\nGenerating: %r\n' % file_path)
+
+
+def send_auto_gen(file_path):
+    send('>>> Generating: %r\n' % file_path)
+
 
 def send_fail_gen(error):
-    send('Generate Error: %s\n'%error)
-    send('>>> Failure\n')
+    send('Generate Error: %s\n>>> Failure\n' % error)
     traceback.print_exc()
 
-################# functions for executing flow graphs   ########################################
+
 def send_start_exec(file_path):
-    send('\nExecuting: ' + repr(file_path) + '\n')
+    send('\nExecuting: %r\n' % file_path)
+
 
 def send_verbose_exec(verbose):
     send(verbose)
 
-def send_end_exec(returncode=0):
-    send('\n>>> Done%s\n' % (" (return code %s)" % returncode if returncode else ""))
 
-################# functions for saving flow graphs  ########################################
+def send_end_exec(code=0):
+    send('\n>>> Done%s\n' % (" (return code %s)" % code if code else ""))
+
+
 def send_fail_save(file_path):
-    send('>>> Error: Cannot save: %s\n'%file_path)
+    send('>>> Error: Cannot save: %s\n' % file_path)
 
-################# functions for connections ########################################
+
 def send_fail_connection():
     send('>>> Error: Cannot create connection.\n')
 
-################# functions for preferences ########################################
+
 def send_fail_load_preferences(prefs_file_path):
-    send('>>> Error: Cannot load preferences file: "%s"\n'%prefs_file_path)
+    send('>>> Error: Cannot load preferences file: "%s"\n' % prefs_file_path)
+
 
 def send_fail_save_preferences(prefs_file_path):
-    send('>>> Error: Cannot save preferences file: "%s"\n'%prefs_file_path)
+    send('>>> Error: Cannot save preferences file: "%s"\n' % prefs_file_path)
 
-################# functions for warning ########################################
+
 def send_warning(warning):
-    send('>>> Warning: %s\n'%warning)
+    send('>>> Warning: %s\n' % warning)


### PR DESCRIPTION
With this GRC will automatically attempt to generate missing hier_blocks when loading a flowgraph. Use-case is easy bootstrapping of flow-graphs with a lot of grc-generated hier_block dependencies).

- the key of each missing hier_block must match its filename.
- there is a per-flowgraph setting to specify a search path (default is ".") This way all hier blocks can be kept in a subdir.
- (nested missing hier blocks work)

Once all needed hier_blocks are generated, they are not regenerated again. I am opened to add optional auto-updating changed grc hier blocks before generate in the future.