### PR TITLE
GRC wouldn't accept non-ASCII in author; I wouldn't accept that

### DIFF
--- a/grc/python/Generator.py
+++ b/grc/python/Generator.py
@@ -22,6 +22,7 @@ import sys
 import subprocess
 import tempfile
 import shlex
+import codecs
 from distutils.spawn import find_executable
 from Cheetah.Template import Template
 
@@ -107,7 +108,7 @@ class TopBlockGenerator(object):
                                       "This is usually undesired. Consider "
                                       "removing the throttle block.")
         # generate
-        with open(self.get_file_path(), 'w') as fp:
+        with codecs.open(self.get_file_path(), 'w', encoding = 'utf-8') as fp:
             fp.write(self._build_python_code_from_template())
         try:
             os.chmod(self.get_file_path(), self._mode)

--- a/grc/python/flow_graph.tmpl
+++ b/grc/python/flow_graph.tmpl
@@ -1,6 +1,7 @@
 #if not $generate_options.startswith('hb')
 #!/usr/bin/env python2
 #end if
+# -*- coding: utf-8 -*-
 ########################################################
 ##Cheetah template - gnuradio_python
 ##


### PR DESCRIPTION
Now, the Generator.py uses codecs to write UTF-8 encoded python. The template contains the magical line to make Python decode the file correctly.