### PR TITLE
Custom Code Blocks

### DIFF
--- a/grc/base/FlowGraph.py
+++ b/grc/base/FlowGraph.py
@@ -209,6 +209,12 @@ class FlowGraph(Element):
 
     get_children = get_elements
 
+    def iter_enabled_blocks(self):
+        """
+        Get an iterator of all blocks that are enabled and not bypassed.
+        """
+        return ifilter(methodcaller('get_enabled'), self.iter_blocks())
+
     def get_enabled_blocks(self):
         """
         Get a list of all blocks that are enabled and not bypassed.
@@ -216,7 +222,7 @@ class FlowGraph(Element):
         Returns:
             a list of blocks
         """
-        return filter(methodcaller('get_enabled'), self.iter_blocks())
+        return list(self.iter_enabled_blocks())
 
     def get_bypassed_blocks(self):
         """

--- a/grc/blocks/epy_block.xml
+++ b/grc/blocks/epy_block.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <block>
-    <name>Embedded Python Block</name>
+    <name>Python Block</name>
     <key>epy_block</key>
     <category>Misc</category>
     <import></import>

--- a/grc/blocks/epy_module.xml
+++ b/grc/blocks/epy_module.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<block>
+	<name>Python Module</name>
+	<key>epy_module</key>
+	<category>Misc</category>
+	<import>import $id  # embedded python module</import>
+	<make></make>
+	<param>
+		<name>Code</name>
+		<key>source_code</key>
+		<value># this module will be imported in the into your flowgraph</value>
+		<type>_multiline_python_external</type>
+		<hide>part</hide>
+	</param>
+	<doc>This block lets you embed a python module in your flowgraph.
+
+Code you put in this module is accessible in other blocks using the ID of this
+block. Example:
+
+If you put
+
+    a = 2
+
+    def double(arg):
+        return 2 * arg
+
+in a Python Module Block with the ID 'stuff' you can use code like
+
+    stuff.a  # evals to 2
+    stuff.double(3)  # evals to 6
+
+to set parameters of other blocks in your flowgraph.</doc>
+</block>

--- a/grc/gui/Param.py
+++ b/grc/gui/Param.py
@@ -345,7 +345,7 @@ class FileParam(EntryParam):
 
 PARAM_MARKUP_TMPL="""\
 #set $foreground = $param.is_valid() and 'black' or 'red'
-<span foreground="$foreground" font_desc="$font"><b>$encode($param.get_name()): </b>$encode(repr($param))</span>"""
+<span foreground="$foreground" font_desc="$font"><b>$encode($param.get_name()): </b>$encode(repr($param).replace('\\n',' '))</span>"""
 
 PARAM_LABEL_MARKUP_TMPL="""\
 #set $foreground = $modified and 'blue' or $param.is_valid() and 'black' or 'red'

--- a/grc/gui/PropsDialog.py
+++ b/grc/gui/PropsDialog.py
@@ -210,6 +210,14 @@ class PropsDialog(gtk.Dialog):
 
         buffer = self._code_text_display.get_buffer()
         block = self._block
+        key = block.get_key()
+
+        if key == 'epy_block':
+            src = block.get_param('_source_code').get_value()
+        elif key == 'epy_module':
+            src = block.get_param('source_code').get_value()
+        else:
+            src = ''
 
         def insert(header, text):
             if not text:
@@ -219,9 +227,11 @@ class PropsDialog(gtk.Dialog):
 
         buffer.delete(buffer.get_start_iter(), buffer.get_end_iter())
         insert('# Imports\n', '\n'.join(block.get_imports()))
-        if block.get_key().startswith('variable'):
+        if key.startswith('variable'):
             insert('\n\n# Variables\n', block.get_var_make())
         insert('\n\n# Blocks\n', block.get_make())
+        if src:
+            insert('\n\n# External Code ({}.py)\n'.format(block.get_id()), src)
 
     def _handle_key_press(self, widget, event):
         """

--- a/grc/python/FlowGraph.py
+++ b/grc/python/FlowGraph.py
@@ -16,11 +16,12 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 """
+import re
+from operator import methodcaller
 
-import expr_utils
+from . import expr_utils
 from .. base.FlowGraph import FlowGraph as _FlowGraph
 from .. gui.FlowGraph import FlowGraph as _GUIFlowGraph
-import re
 
 _variable_matcher = re.compile('^(variable\w*)$')
 _parameter_matcher = re.compile('^(parameter)$')
@@ -181,8 +182,8 @@ class FlowGraph(_FlowGraph, _GUIFlowGraph):
         Returns:
             a sorted list of variable blocks in order of dependency (indep -> dep)
         """
-        variables = filter(lambda b: _variable_matcher.match(b.get_key()), self.get_enabled_blocks())
-        return expr_utils.sort_objects(variables, lambda v: v.get_id(), lambda v: v.get_var_make())
+        variables = filter(lambda b: _variable_matcher.match(b.get_key()), self.iter_enabled_blocks())
+        return expr_utils.sort_objects(variables, methodcaller('get_id'), methodcaller('get_var_make'))
 
     def get_parameters(self):
         """
@@ -191,16 +192,16 @@ class FlowGraph(_FlowGraph, _GUIFlowGraph):
         Returns:
             a list of paramterized variables
         """
-        parameters = filter(lambda b: _parameter_matcher.match(b.get_key()), self.get_enabled_blocks())
+        parameters = filter(lambda b: _parameter_matcher.match(b.get_key()), self.iter_enabled_blocks())
         return parameters
 
     def get_monitors(self):
         """
         Get a list of all ControlPort monitors
         """
-        monitors = filter(lambda b: _monitors_searcher.search(b.get_key()), self.get_enabled_blocks())
+        monitors = filter(lambda b: _monitors_searcher.search(b.get_key()),
+                          self.iter_enabled_blocks())
         return monitors
-
 
     def get_bussink(self):
         bussink = filter(lambda b: _bussink_searcher.search(b.get_key()), self.get_enabled_blocks())

--- a/grc/python/Generator.py
+++ b/grc/python/Generator.py
@@ -181,9 +181,13 @@ class TopBlockGenerator(object):
         blocks = filter(lambda b: b not in (imports + parameters), blocks)
 
         for block in blocks:
-            if block.get_key() == 'epy_block':
-                file_path = os.path.join(self._dirname, block.get_id() + '.py')
+            key = block.get_key()
+            file_path = os.path.join(self._dirname, block.get_id() + '.py')
+            if key == 'epy_block':
                 src = block.get_param('_source_code').get_value()
+                output.append((file_path, src))
+            elif key == 'epy_module':
+                src = block.get_param('source_code').get_value()
                 output.append((file_path, src))
 
         # Filter out virtual sink connections

--- a/grc/python/Param.py
+++ b/grc/python/Param.py
@@ -31,7 +31,7 @@ from Constants import VECTOR_TYPES, COMPLEX_TYPES, REAL_TYPES, INT_TYPES
 from gnuradio import eng_notation
 
 _check_id_matcher = re.compile('^[a-z|A-Z]\w*$')
-_show_id_matcher = re.compile('^(variable\w*|parameter|options|notebook)$')
+_show_id_matcher = re.compile('^(variable\w*|parameter|options|notebook|epy_module)$')
 
 
 #blacklist certain ids, its not complete, but should help

--- a/grc/python/flow_graph.tmpl
+++ b/grc/python/flow_graph.tmpl
@@ -68,7 +68,6 @@ sys.path.append(os.environ.get('GRC_HIER_PATH', os.path.expanduser('~/.grc_gnura
 ##$(imp.replace("  # grc-generated hier_block", ""))
 $imp
 #end for
-
 ########################################################
 ##Create Class
 ##  Write the class declaration for a top or hier block.
@@ -82,6 +81,7 @@ $imp
     #import gtk
     #set $icon = gtk.IconTheme().lookup_icon('gnuradio-grc', 32, 0)
 
+
 class $(class_name)(grc_wxgui.top_block_gui):
 
     def __init__($param_str):
@@ -91,6 +91,7 @@ class $(class_name)(grc_wxgui.top_block_gui):
         self.SetIcon(wx.Icon(_icon_path, wx.BITMAP_TYPE_ANY))
     #end if
 #elif $generate_options == 'qt_gui'
+
 
 class $(class_name)(gr.top_block, Qt.QWidget):
 
@@ -118,6 +119,7 @@ class $(class_name)(gr.top_block, Qt.QWidget):
         self.restoreGeometry(self.settings.value("geometry").toByteArray())
 #elif $generate_options == 'no_gui'
 
+
 class $(class_name)(gr.top_block):
 
     def __init__($param_str):
@@ -125,6 +127,7 @@ class $(class_name)(gr.top_block):
 #elif $generate_options.startswith('hb')
     #set $in_sigs = $flow_graph.get_hier_block_stream_io('in')
     #set $out_sigs = $flow_graph.get_hier_block_stream_io('out')
+
 
 #if $generate_options == 'hb_qt_gui'
 class $(class_name)(gr.hier_block2, Qt.QWidget):


### PR DESCRIPTION
This adds a new block that allows to enter arbitrary python code which is inserted between the imports and the top/hier_block class in the generated code. Consequently, this code can be accessed/used by other variables/blocks. Variables, however, can not be used inside the custom code (too much magic).
It builds on the ability to enter multi-line python code with an external editor introduced with embedded python blocks.

@trondeau, is this what you had in mind (Dev Call Oct)