### PR TITLE
Improved block searching

### DIFF
--- a/gr-digital/grc/digital_mpsk_receiver_cc.xml
+++ b/gr-digital/grc/digital_mpsk_receiver_cc.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>MPSK Receiver</name>
 	<key>digital_mpsk_receiver_cc</key>
+	<tags>phase shift keying</tags>
 	<import>from gnuradio import digital;import cmath</import>
 	<make>digital.mpsk_receiver_cc($M, $theta, $w, $fmin, $fmax, $mu, $gain_mu, $omega, $gain_omega, $omega_relative_limit)</make>
 	<callback>set_loop_bandwidth($w)</callback>

--- a/gr-digital/grc/digital_mpsk_snr_est_cc.xml
+++ b/gr-digital/grc/digital_mpsk_snr_est_cc.xml
@@ -7,6 +7,7 @@
 <block>
 	<name>MPSK SNR Estimator</name>
 	<key>digital_mpsk_snr_est_cc</key>
+	<tags>phase shift keying</tags>
 	<import>from gnuradio import digital</import>
 	<make>digital.mpsk_snr_est_cc($type, $tag_nsamples, $alpha)</make>
 	<callback>set_type($type)</callback>

--- a/gr-digital/grc/digital_psk_demod.xml
+++ b/gr-digital/grc/digital_psk_demod.xml
@@ -29,6 +29,7 @@
 <block>
   <name>PSK Demod</name>
   <key>digital_psk_demod</key>
+  <tags>phase shift keying, demodulator</tags>
   <import>from gnuradio import digital</import>
   <make>digital.psk.psk_demod(
   constellation_points=$constellation_points,

--- a/gr-digital/grc/digital_psk_mod.xml
+++ b/gr-digital/grc/digital_psk_mod.xml
@@ -29,6 +29,7 @@
 <block>
   <name>PSK Mod</name>
   <key>digital_psk_mod</key>
+  <tags>phase shift keying, modulator</tags>
   <import>from gnuradio import digital</import>
   <make>digital.psk.psk_mod(
   constellation_points=$constellation_points,

--- a/grc/base/Block.py
+++ b/grc/base/Block.py
@@ -82,6 +82,7 @@ class Block(Element):
         self._key = n.find('key')
         self._category = n.find('category') or ''
         self._flags = n.find('flags') or ''
+        self._tags = n.find('tags') or ''
         # Backwards compatibility
         if n.find('throttle') and BLOCK_FLAG_THROTTLE not in self._flags:
             self._flags += BLOCK_FLAG_THROTTLE
@@ -320,6 +321,7 @@ class Block(Element):
     def get_comment(self): return self.get_param('comment').get_value()
 
     def get_flags(self): return self._flags
+    def get_tags(self): return self._tags
     def throtteling(self): return BLOCK_FLAG_THROTTLE in self._flags
     def bypass_disabled(self): return BLOCK_FLAG_DISABLE_BYPASS in self._flags
 

--- a/grc/base/Block.py
+++ b/grc/base/Block.py
@@ -310,6 +310,7 @@ class Block(Element):
     def get_key(self): return self._key
     def get_category(self): return self._category
     def set_category(self, cat): self._category = cat
+
     def get_doc(self): return ''
     def get_ports(self): return self.get_sources() + self.get_sinks()
     def get_ports_gui(self): return self.filter_bus_port(self.get_sources()) + self.filter_bus_port(self.get_sinks());

--- a/grc/base/Platform.py
+++ b/grc/base/Platform.py
@@ -216,7 +216,7 @@ class Platform(_Element):
                 block = self.get_block(block_key)
                 #if it exists, the block's category shall not be overridden by the xml tree
                 if not block.get_category():
-                    block.set_category(parent)
+                    block.set_category('/'.join(c for c in parent if c))
 
         # recursively load the category trees and update the categories for each block
         for category_tree_n in self._category_trees_n:

--- a/grc/gui/BlockTreeWindow.py
+++ b/grc/gui/BlockTreeWindow.py
@@ -217,7 +217,7 @@ class BlockTreeWindow(gtk.VBox):
             # the search string
             def search(block):
                 words = [block.get_name(), block.get_key(),
-                         block.get_category()] #, block.get_tags()]
+                         block.get_category(), block.get_tags()]
                 for key in keys:
                     if not any(key in word.lower() for word in words):
                         return False

--- a/grc/python/block.dtd
+++ b/grc/python/block.dtd
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
     Top level element.
     A block contains a name, ...parameters list, and list of IO ports.
  -->
-<!ELEMENT block (name, key, category?, throttle?, flags?, import*, var_make?, var_value?,
+<!ELEMENT block (name, key, category?, throttle?, flags?, tags?, import*, var_make?, var_value?,
         make, callback*, param_tab_order?, param*, bus_sink?, bus_source?, check*,
         sink*, source*, bus_structure_sink?, bus_structure_source?, doc?,  grc_source?)>
 <!--
@@ -67,3 +67,4 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA
 <!ELEMENT optional (#PCDATA)>
 <!ELEMENT throttle (#PCDATA)>
 <!ELEMENT flags (#PCDATA)>
+<!ELEMENT tags (#PCDATA)>


### PR DESCRIPTION
Searching for blocks in the tree now matches against individual words in the search string rather than the entire string. Example: "qt freq" returns a valid match now.

Added a <tags> element to the block dtd with a couple of examples. The block tags and category are also included in the search, and final results are sorted by category. 




