### PR TITLE
speed-up GRC

### DIFF
--- a/grc/gui/Utils.py
+++ b/grc/gui/Utils.py
@@ -101,19 +101,26 @@ def encode(value):
     return gobject.markup_escape_text(valid_utf8)
 
 
-def parse_template(tmpl_str, **kwargs):
-    """
-    Parse the template string with the given args.
-    Pass in the xml encode method for pango escape chars.
+class TemplateParser(object):
+    def __init__(self):
+        self.cache = {}
 
-    Args:
-        tmpl_str: the template as a string
+    def __call__(self, tmpl_str, **kwargs):
+        """
+        Parse the template string with the given args.
+        Pass in the xml encode method for pango escape chars.
 
-    Returns:
-        a string of the parsed template
-    """
-    kwargs['encode'] = encode
-    return str(Template(tmpl_str, kwargs))
+        Args:
+            tmpl_str: the template as a string
+
+        Returns:
+            a string of the parsed template
+        """
+        kwargs['encode'] = encode
+        template = self.cache.setdefault(tmpl_str, Template.compile(tmpl_str))
+        return str(template(namespaces=kwargs))
+
+parse_template = TemplateParser()
 
 
 def align_to_grid(coor):


### PR DESCRIPTION
I can't believe I haven't thought of this before.

Instead of compiling Cheetah templates for each rendering anew, we use a simple cache of previously compiled templates. Since we render the same templates over and over again this results in a major speed-up...

@jmcorgan, any chance we can put this in the release (pending @sdh11's review)?